### PR TITLE
use organization's PAT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       
       - name: Setup GitHub token
         run: |
-          git config --global url."https://Saza-ku:${{ secrets.PAT }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://Notch-Technologies:${{ secrets.GH_PAT_ORG }}@github.com".insteadOf "https://github.com"
 
       - name: Get dependencies
         run: |


### PR DESCRIPTION
The PAT is used in the public repository. So we should use the fine-grained PAT.